### PR TITLE
Reordered the code for target group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -103,6 +103,23 @@ resource "aws_lb_listener_rule" "asg" {
     }
 }
 
+resource "aws_lb_target_group" "asg" {
+    name        = "terraform-asg-example"
+    port        = var.server_port
+    protocol    = "HTTP"
+    vpc_id      = data.aws_vpc.default.id
+
+    health_check {
+      path                  = "/"
+      protocol              = "HTTP"
+      matcher               = "200"
+      interval              = 15
+      timeout               = 3
+      healthy_threshold     = 2
+      unhealthy_threshold   = 2
+    }
+}
+
 resource "aws_security_group" "alb" {
     name = "terraform-example-alb"
 
@@ -120,23 +137,6 @@ resource "aws_security_group" "alb" {
         to_port         = 0
         protocol        = "-1"
         cidr_blocks     = ["0.0.0.0/0"] 
-    }
-}
-
-resource "aws_lb_target_group" "asg" {
-    name        = "terraform-asg-example"
-    port        = var.server_port
-    protocol    = "HTTP"
-    vpc_id      = data.aws_vpc.default.id
-
-    health_check {
-      path                  = "/"
-      protocol              = "HTTP"
-      matcher               = "200"
-      interval              = 15
-      timeout               = 3
-      healthy_threshold     = 2
-      unhealthy_threshold   = 2
     }
 }
 


### PR DESCRIPTION
Considering the order of how the aws resources are needed, I had to reorder the location of where the "aws_lb_target_group" was placed in the main.tf file.

DOD: place the code right after aws_lb_listerner_rule resource